### PR TITLE
Fix dlopen problem by not resolving localhost

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ pub struct CommandResponse {
 }
 
 fn get_spawner_url() -> String {
-    "http://localhost:8099/command".to_string()
+    "http://127.0.0.1:8099/command".to_string()
 }
 
 pub fn sync_remote_execute(cmd: &str) -> (i32, String, String) {


### PR DESCRIPTION
By using 127.0.0.1 instead of localhost the hostname does not need to be resolved which eliminates [this problem](https://github.com/scontain/ceremony-deployment-vector-based/issues/27#issuecomment-2405345199).